### PR TITLE
Removed "LOCAL" from "LOAD DATA INFILE" command

### DIFF
--- a/CRM/Finance/Utils/DataExchange.php
+++ b/CRM/Finance/Utils/DataExchange.php
@@ -60,8 +60,7 @@ class CRM_Finance_Utils_DataExchange {
         $setFieldsSql = implode(', ', $setFields);
         $columnFieldsSql = implode(', ', $columnFields);
         
-        CRM_Core_DAO::executeQuery("SET GLOBAL local_infile = 1");
-        $sql = "LOAD DATA LOCAL INFILE '$fileName' INTO TABLE $tableName
+        $sql = "LOAD DATA INFILE '$fileName' INTO TABLE $tableName
             CHARACTER SET {$params['characterSet']}
             FIELDS TERMINATED BY '{$params['fieldsTerminatedBy']}'
                 OPTIONALLY ENCLOSED BY '{$params['optionallyEnclosedBy']}'
@@ -107,8 +106,7 @@ class CRM_Finance_Utils_DataExchange {
         
         $setFieldsSql = implode(', ', $setFields);
         
-        CRM_Core_DAO::executeQuery("SET GLOBAL local_infile = 1");
-        $sql = "LOAD DATA LOCAL INFILE '$fileName' INTO TABLE $tableName
+        $sql = "LOAD DATA INFILE '$fileName' INTO TABLE $tableName
             CHARACTER SET {$params['characterSet']}
             IGNORE {$params['ignoreLines']} LINES
             (@var) SET status = 0, {$setFieldsSql}";


### PR DESCRIPTION
The LOCAL was stopping it working in mysql 5.5.41 despite having local-infile set to ON and the user having both SUPER and FILE privileges.

Since most users will probably run this code on the same machine as their DB (and since those who don't are likely to be the more sophisticated users) I suggest using just LOAD DATA INFILE.

Removing the SET GLOBAL command also means we don't have to grant SUPER, which is clearly an advantage from a security perspective!
